### PR TITLE
Radix Trees

### DIFF
--- a/src/lang.h
+++ b/src/lang.h
@@ -2,9 +2,9 @@
 #define LANG_H
 
 typedef enum {
-  t_ILLEGAL = 0,
-  t_Type,  t_Modifier, t_Keyword, t_State, t_Symbol,
-  t_Ident, t_Literal
+        t_ILLEGAL = 0,
+        t_Type,  t_Modifier, t_Keyword, t_State, t_Symbol,
+        t_Ident, t_Literal
 } tokenType;
 
 typedef enum {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -35,7 +35,7 @@ typedef struct {
 
 /*
  * scanToken represents the main output structure of
- * the scanner. It descripes the token, its type and
+ * the scanner. It describes the token, its type and
  * (if applicable) its literal and string values.
  */
 typedef struct {

--- a/src/tree/node.cpp
+++ b/src/tree/node.cpp
@@ -36,7 +36,7 @@ bool Node::hasChildren()
 
 void Node::setParent(Node* parent)
 {
-        if (parent == nullptr)
+        if (parent == nullptr || Parent == parent)
                 return;
 
         Node* prev = PrevSibling;
@@ -50,7 +50,6 @@ void Node::setParent(Node* parent)
 
         /* Node's siblings will be configured by addChild().*/
         parent->addChild(this);
-
 }
 
 bool Node::addChild(Node* child)
@@ -66,6 +65,8 @@ bool Node::addChild(Node* child)
 
         if (FirstChild == nullptr)
                 FirstChild = child;
+
+        return true;
 }
 
 void Node::getChildren(std::vector<Node*>& children)

--- a/src/tree/node.cpp
+++ b/src/tree/node.cpp
@@ -10,12 +10,8 @@ Node::~Node()
         }
 }
 
-nodeType Node::getType() {
-        return Type;
-}
-
 bool Node::hasParent() {
-        return (Parent != nullptr) ? true : false;
+        return (Parent != nullptr);
 }
 
 bool Node::hasSiblings()
@@ -57,6 +53,12 @@ bool Node::addChild(Node* child)
         if (child == nullptr)
                 return false;
 
+        /* Adding same-value nodes is permitted, but addresses
+         * shouldn't be the same.
+         */
+        if (child == this)
+                return false;
+
         if (LastChild != nullptr)
                 LastChild->setSiblings(LastChild->prevSibling(), child);
 
@@ -66,6 +68,7 @@ bool Node::addChild(Node* child)
         if (FirstChild == nullptr)
                 FirstChild = child;
 
+        child->Parent = this;
         return true;
 }
 
@@ -124,4 +127,28 @@ void Node::setSiblings(Node* prev, Node* next)
 {
         NextSibling = next;
         PrevSibling = prev;
+}
+
+bool Node::operator==(const Node& rhs)
+{
+        if (this->Parent != rhs.Parent)
+                return false;
+
+        if (this->PrevSibling != rhs.PrevSibling)
+                return false;
+
+        if (this->NextSibling != rhs.NextSibling)
+                return false;
+
+        if (this->FirstChild != rhs.FirstChild)
+                return false;
+
+        if (this->LastChild != rhs.LastChild)
+                return false;
+
+        return true;
+}
+
+bool Node::operator!=(const Node& rhs) {
+        return !(*this == rhs);
 }

--- a/src/tree/node.h
+++ b/src/tree/node.h
@@ -11,11 +11,6 @@ typedef enum {
         SKIP_CHILDREN
 } walkStatus;
 
-/* TODO */
-typedef enum {
-        NONE = 0
-} nodeType;
-
 /*
  * walkStatus defines a callback fn tupe for preorder
  * tree traversal. Node is the current node visited and
@@ -26,20 +21,20 @@ typedef walkStatus (*walkFn) (Node* node, bool entering);
 
 class Node
 {
-private:
+protected:
         Node* Parent      = nullptr;
         Node* PrevSibling = nullptr;
         Node* NextSibling = nullptr;
         Node* FirstChild  = nullptr;
         Node* LastChild   = nullptr;
 
-        nodeType Type         = NONE;
-        walkFn   WalkCallback = nullptr;
+        walkFn WalkCallback = nullptr;
 public:
         Node(){};
         ~Node();
 
-        nodeType getType();
+        bool operator==(const Node& rhs);
+        bool operator!=(const Node& rhs);
 
         bool hasParent();
         bool hasSiblings();

--- a/src/tree/radix-tree.cpp
+++ b/src/tree/radix-tree.cpp
@@ -1,0 +1,94 @@
+#include "radix-tree.h"
+
+bool parseDef::operator==(const parseDef& rhs)
+{
+        if (this->wantToken != rhs.wantToken)
+                return false;
+
+        if (this->tok != rhs.tok)
+                return false;
+
+        if (this->type != rhs.type)
+                return false;
+
+        return true;
+}
+
+unsigned int _countVectorEq(std::vector<parseDef>& x, std::vector<parseDef>& y)
+{
+        unsigned int count = 0;
+        auto xit = x.begin();
+        auto yit = y.begin();
+
+        while (xit != x.end() && yit != y.end()) {
+                if (*xit == *yit)
+                        count++;
+
+                ++xit;
+                ++yit;
+        }
+
+        return count;
+}
+
+void RadixNode::setParent(RadixNode* parent)
+{
+        if (parent == nullptr || this->Parent == parent)
+                return;
+
+        parent->addChild(this);
+}
+
+bool RadixNode::addChild(RadixNode* child)
+{
+        if (child == nullptr || *child == *this)
+                return false;
+
+        if (child->data.size() == 0 || child->data.size() > 3)
+                return false;
+
+        unsigned int same = _countVectorEq(data, child->data);
+        if (!same)
+                return false;
+
+        for (int i = 0; i < same; i++)
+                child->data.erase(child->data.begin());
+
+        RadixNode* sChild = (RadixNode*)firstChild();
+        while (sChild != nullptr) {
+                // child belongs lower down the tree
+                if (_countVectorEq(sChild->data, child->data))
+                        return sChild->addChild(child);
+
+                sChild = (RadixNode*)sChild->nextSibling();
+        }
+
+        // No common children found, split parent into new parent
+        RadixNode* newParent = new RadixNode;
+        for (int i = 0; i < same; i++) {
+                newParent->data.push_back(*data.begin());
+                data.erase(data.begin());
+        }
+
+        // Node base class doesn't doesn't care about radix.
+        newParent->Node::setParent(this->Parent);
+        newParent->Node::addChild(this);
+        newParent->Node::addChild(child);
+
+        return true;
+}
+
+bool RadixNode::operator==(RadixNode& rhs)
+{
+        if (this->data.size() != rhs.data.size())
+                return false;
+
+        if (_countVectorEq(this->data, rhs.data) != this->data.size())
+                return false;
+
+        return true;
+}
+
+bool RadixNode::operator!=(RadixNode& rhs) {
+        return !(*this == rhs);
+}

--- a/src/tree/radix-tree.h
+++ b/src/tree/radix-tree.h
@@ -1,0 +1,35 @@
+#ifndef RADIX_TREE_H
+#define RADIX_TREE_H
+
+#include <cstdarg>
+#include <vector>
+
+#include "node.h"
+#include "../lang.h"
+
+struct parseDef {
+        bool wantToken;
+
+        token     tok  = ILLEGAL;
+        tokenType type = t_ILLEGAL;
+
+        bool operator==(const parseDef& rhs);
+
+};
+typedef struct parseDef parseDef;
+
+class RadixNode : public Node
+{
+public:
+        RadixNode(){};
+
+        std::vector<parseDef> data;
+
+        void setParent(RadixNode* parent);
+        bool addChild(RadixNode* child);
+
+        bool operator==(RadixNode& rhs);
+        bool operator!=(RadixNode& rhs);
+};
+
+#endif /* RADIX_TREE_H */


### PR DESCRIPTION
Considering that most rinto language expressions and statements have repeating judgement forms, the most space (and to a lesser extent, time) efficient way to evaluate whether a scanned expression matches a judgement form is via radix lookup. 

This PR (⚠️**work in progress**) introduces self-arranging radix tree nodes, as well as a general radix interface for performing lookup.