### PR TITLE
CI/CD Fix

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Install dependencies on Ubuntu-latest
       run: |
           sudo apt-get update
-          sudo apt-get install libmpfr-dev
-          gcc --version
+          sudo apt-get install libmpfr-dev libmpfr6
           g++ --version
-    - name: make
-      run: make
+    - name: Debug-Scanner Module
+      run: make debug-scanner
+    - name: Debug-Parser Module
+      run: make debug-parser

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ CPP=g++
 FRONT-DIR=./src/frontend
 DEBUG-DIR=./src/debug-tools
 BUILD-DIR=./build
-CPP-OPTS=-std=c++14 -Wall -lmpfr -I$(FRONT-DIR)
+CPP-OPTS=-std=c++14 -Wall
+DEPS = -I$(FRONT-DIR) -lmpfr -lgmp
 
 FRONTEND_SRC=$(FRONT-DIR)/diagnostic.cc $(FRONT-DIR)/file.cc 	      \
 						 $(FRONT-DIR)/operators.cc $(FRONT-DIR)/scanner.cc      \
@@ -10,10 +11,12 @@ FRONTEND_SRC=$(FRONT-DIR)/diagnostic.cc $(FRONT-DIR)/file.cc 	      \
 						 $(FRONT-DIR)/parser.cc
 
 debug-scanner: build-dir
-	$(CPP) $(CPP-OPTS) -I$(DEBUG-DIR) -o $(BUILD-DIR)/a.out $(DEBUG-DIR)/scanner.cc $(DEBUG-DIR)/debug-diagnostic.cc $(FRONTEND_SRC)
+	$(CPP) $(CPP-OPTS) -o $(BUILD-DIR)/debug-scanner.out $(DEBUG-DIR)/scanner.cc \
+	$(DEBUG-DIR)/debug-diagnostic.cc -I$(DEBUG-DIR) $(FRONTEND_SRC) $(DEPS)
 
 debug-parser: build-dir
-	$(CPP) $(CPP-OPTS) -I$(DEBUG-DIR) -o $(BUILD-DIR)/a.out $(DEBUG-DIR)/parser.cc $(DEBUG-DIR)/debug-diagnostic.cc $(FRONTEND_SRC)
+	$(CPP) $(CPP-OPTS) -o $(BUILD-DIR)/debug-parser.out $(DEBUG-DIR)/parser.cc \
+	$(DEBUG-DIR)/debug-diagnostic.cc -I$(DEBUG-DIR) $(FRONTEND_SRC) $(DEPS)
 
 build-dir:
 	@mkdir -p build


### PR DESCRIPTION
1. Changed order of dependencies, placing `-lmpfr -lgmp` last as per [reference](https://stackoverflow.com/questions/65448452/mpfr-undefined-reference-incorrect-installation).
2. Added debug-parser tool to C++ workflow.